### PR TITLE
chore: bump c360 chart to 0.19.0

### DIFF
--- a/chart/edb-cnpg-gke-autopilot/requirements.yaml
+++ b/chart/edb-cnpg-gke-autopilot/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: cloudnative-pg
-    version: 0.18.0
+    version: 0.19.0
     repository: https://cloudnative-pg.github.io/charts


### PR DESCRIPTION
Coinciding with the 1.21.0 operator release